### PR TITLE
Add artifact impact graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 .idea
+.junie
 .claude
 .agents
 .codex
@@ -10,4 +11,3 @@ Cargo.lock
 .DS_Store
 /.github/skills
 !/.github
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ No partial changes. If you add a field to `project.yaml`, all five layers must r
 | TRC | traceability | Traceability mappings |
 | PLN | plan | Implementation plan |
 | STK | stack | Tech stack components |
+| ART | artifacts | Artifact dependency graph, impact, owners, references |
 | MST | milestone | Milestone tracking (milestones.yaml) |
 
 When adding a new validation domain, register a new prefix here.

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -299,6 +299,7 @@ Every LLM agent MUST start by reading `project.yaml` (global configuration), the
 **`project.yaml`** contains global data:
 - **paths** - where directories and files live; `paths.llm.map` points to `llm/map.yaml`
 - **stack** - technical stack: components with types, languages, and typed dependencies
+- **artifact_graph** - path-based ownership for code/test/doc nodes that participate in the artifact dependency graph
 
 **`milestones.yaml`** contains:
 - **current** - current milestone: id, branch, stage, stages with their statuses
@@ -307,6 +308,53 @@ Every LLM agent MUST start by reading `project.yaml` (global configuration), the
 Status, contracts, plan, and questions live inside `human/milestones/{id}/`.
 
 Updated automatically after every `/generate` and `/verify`.
+
+### 5.1a Artifact Dependency Graph
+
+Markdown artifacts MAY declare YAML frontmatter:
+
+```yaml
+---
+id: adr-auth-session
+type: adr
+status: accepted
+owners: [platform]
+depends_on: [spec-auth]
+affects: [architecture-auth, code-auth-session, tests-auth-session]
+---
+```
+
+Supported relations are `requires`/`depends_on`, `implements`, `verifies`, `documents`, `supersedes`, `conflicts_with`, and `affects`. Reverse traceability is first-class: if code ownership says `code-auth-session implements adr-auth-session`, changing `adr-auth-session` impacts `code-auth-session` even if the ADR forgot to list it in `affects`.
+
+Code ownership lives in `project.yaml -> artifact_graph.code_ownership`:
+
+```yaml
+artifact_graph:
+  code_ownership:
+    code-auth-session:
+      paths: [src/auth/**]
+      owners: [platform]
+      implements: [spec-auth, adr-auth-session]
+```
+
+`hlv artifacts impact <id-or-path>` prints downstream artifacts to review. `hlv artifacts impact --changed` derives changed artifacts from git worktree status, while `hlv artifacts impact --changed --base <ref>` compares committed PR changes from the merge-base of `<ref>` and `HEAD`. Both modes include Markdown artifact paths and `artifact_graph.code_ownership.paths`. `hlv artifacts sync` creates missing `project.yaml -> artifact_graph.code_ownership` stubs for referenced `code-*`, `tests-*`, `docs-*`, and `clients-*` nodes. `hlv artifacts audit` and `hlv check` validate owners, dangling references, accepted ADR architecture linkage, accepted conflicts, and duplicate artifact IDs; audit exits non-zero when ART errors are present.
+
+Files inside owned code/test/doc/client paths SHOULD include file-level evidence markers:
+
+```rust
+// @hlv:artifact code-auth implements spec-auth
+// @hlv:artifact tests-auth verifies spec-auth
+```
+
+Markdown/HTML comments are also valid:
+
+```md
+<!-- @hlv:artifact docs-auth documents spec-auth -->
+```
+
+The marker format is `@hlv:artifact <node-id> <relation> <artifact-id>`, where relation is `implements`, `verifies`, `documents`, or `requires`. `hlv check` emits `ART-050` warnings when `project.yaml` declares an ownership relation with concrete `paths`, but no matching file-level marker is found.
+
+New projects created by `hlv init` include an empty `project.yaml -> artifact_graph.code_ownership` map. Existing projects do not need a migration to keep working. `artifact_graph` and artifact frontmatter are optional; if neither exists, HLV treats the artifact graph as empty and `hlv artifacts audit` prints a migration hint instead of failing. Adopt impact analysis incrementally: add frontmatter to the highest-value specs/ADRs first, then add `artifact_graph.code_ownership` entries for code, tests, generated clients, and docs that need review routing.
 
 **Language selection policy.** HLV prefers strict, compile-time-safe languages where they naturally fit the task. For backend/service/CLI/system components, the default recommendation is to start with strict, compile-time-safe languages that have a strong ecosystem fit.
 This is not dogma: for UI/frontend, bot/automation tasks, glue code, ML/data/AI-chain workloads, and SDK-centric integrations, TypeScript, Python, or another language can and should be chosen if the ecosystem fit is clearly better. Python is not the architectural default, but it can be the best deliberate choice for ML and complex AI chains because of ecosystem maturity. If language choice affects architecture and does not follow from artifacts, the agent must raise it as an open question instead of forcing a language.

--- a/docs/ARCH.md
+++ b/docs/ARCH.md
@@ -326,6 +326,8 @@ affects: [architecture-auth, code-auth-session, tests-auth-session]
 
 Supported relations are `requires`/`depends_on`, `implements`, `verifies`, `documents`, `supersedes`, `conflicts_with`, and `affects`. Reverse traceability is first-class: if code ownership says `code-auth-session implements adr-auth-session`, changing `adr-auth-session` impacts `code-auth-session` even if the ADR forgot to list it in `affects`.
 
+Markdown frontmatter is treated as HLV artifact metadata only when both `id` and `type` are present. Legacy Markdown frontmatter such as `id` + `status`, `title`, `date`, or `tags` is ignored for artifact graph purposes.
+
 Code ownership lives in `project.yaml -> artifact_graph.code_ownership`:
 
 ```yaml
@@ -337,7 +339,7 @@ artifact_graph:
       implements: [spec-auth, adr-auth-session]
 ```
 
-`hlv artifacts impact <id-or-path>` prints downstream artifacts to review. `hlv artifacts impact --changed` derives changed artifacts from git worktree status, while `hlv artifacts impact --changed --base <ref>` compares committed PR changes from the merge-base of `<ref>` and `HEAD`. Both modes include Markdown artifact paths and `artifact_graph.code_ownership.paths`. `hlv artifacts sync` creates missing `project.yaml -> artifact_graph.code_ownership` stubs for referenced `code-*`, `tests-*`, `docs-*`, and `clients-*` nodes. `hlv artifacts audit` and `hlv check` validate owners, dangling references, accepted ADR architecture linkage, accepted conflicts, and duplicate artifact IDs; audit exits non-zero when ART errors are present.
+`hlv artifacts graph` prints all artifact graph nodes and relations, with `--json` returning `nodes` and `edges` for automation. `hlv artifacts impact <id-or-path>` prints downstream artifacts to review. `hlv artifacts impact --changed` derives changed artifacts from git worktree status, while `hlv artifacts impact --changed --base <ref>` compares committed PR changes from the merge-base of `<ref>` and `HEAD`. Both modes include Markdown artifact paths and `artifact_graph.code_ownership.paths`. `hlv artifacts sync` creates missing `project.yaml -> artifact_graph.code_ownership` stubs for referenced `code-*`, `tests-*`, `docs-*`, and `clients-*` nodes. `hlv artifacts audit` and `hlv check` validate owners, dangling references, accepted ADR architecture linkage, accepted conflicts, and duplicate artifact IDs; audit exits non-zero when ART errors are present.
 
 Files inside owned code/test/doc/client paths SHOULD include file-level evidence markers:
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -596,6 +596,7 @@ hlv constraints check --json             # JSON output
 # Artifacts and glossary
 hlv artifacts [--global|--milestone] [--json]
 hlv artifacts show <name> [--json]
+hlv artifacts graph [--json]
 hlv artifacts impact <id-or-path> [--json]
 hlv artifacts impact --changed [--json]
 hlv artifacts impact --changed --base <ref> [--json]
@@ -623,11 +624,12 @@ New projects created by `hlv init` include an empty `project.yaml -> artifact_gr
 
 To adopt the feature gradually:
 
-1. Add frontmatter to key specs, ADRs, and architecture docs.
+1. Add HLV frontmatter to key specs, ADRs, and architecture docs. HLV frontmatter requires both `id` and `type`; legacy Markdown frontmatter without both keys is ignored.
 2. Run `hlv artifacts sync` to create missing `project.yaml -> artifact_graph.code_ownership` stubs for referenced `code-*`, `tests-*`, `docs-*`, and `clients-*` nodes.
 3. Fill concrete `paths` for important code/test/doc path groups.
 4. Add file-level markers such as `@hlv:artifact code-auth implements spec-auth` in owned code/test/doc files.
 5. Run `hlv artifacts audit`.
-6. Use `hlv artifacts impact <id-or-path>`, `hlv artifacts impact --changed` locally, or `hlv artifacts impact --changed --base <target-branch>` in PR review.
+6. Use `hlv artifacts graph` to inspect all artifact nodes and relations.
+7. Use `hlv artifacts impact <id-or-path>`, `hlv artifacts impact --changed` locally, or `hlv artifacts impact --changed --base <target-branch>` in PR review.
 
 For CI usage of `--base`, ensure the checkout has enough history to compute a merge base. With GitHub Actions, fetch the target branch explicitly or use `actions/checkout` with `fetch-depth: 0`.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -204,6 +204,7 @@ The LLM reads all your artifacts and generates:
 | Stages | `stage_1.md`, `stage_2.md`, ... | Tasks for each stage |
 | Open questions | `open-questions.md` | Questions the LLM could not answer |
 | Stack | `project.yaml -> stack` (global) | Components, languages, dependencies |
+| Artifact graph | artifact frontmatter + `project.yaml -> artifact_graph` | Dependencies, downstream impact, owners, code ownership |
 
 ### What you do after `/generate`
 
@@ -595,6 +596,11 @@ hlv constraints check --json             # JSON output
 # Artifacts and glossary
 hlv artifacts [--global|--milestone] [--json]
 hlv artifacts show <name> [--json]
+hlv artifacts impact <id-or-path> [--json]
+hlv artifacts impact --changed [--json]
+hlv artifacts impact --changed --base <ref> [--json]
+hlv artifacts audit [--json]
+hlv artifacts sync [--check] [--json]
 hlv glossary [--json]
 
 # JSON output for automation
@@ -610,3 +616,16 @@ hlv workflow --json
 # Validation
 /validate                    # gates -> release decision
 ```
+
+### Upgrading existing projects
+
+New projects created by `hlv init` include an empty `project.yaml -> artifact_graph.code_ownership` map. Projects created before artifact impact analysis do not need immediate migration. `artifact_graph` in `project.yaml` and YAML frontmatter in Markdown artifacts are optional, so old projects continue to parse and pass graph checks. `hlv artifacts audit` prints a hint when no graph metadata exists and exits non-zero when ART errors are present.
+
+To adopt the feature gradually:
+
+1. Add frontmatter to key specs, ADRs, and architecture docs.
+2. Run `hlv artifacts sync` to create missing `project.yaml -> artifact_graph.code_ownership` stubs for referenced `code-*`, `tests-*`, `docs-*`, and `clients-*` nodes.
+3. Fill concrete `paths` for important code/test/doc path groups.
+4. Add file-level markers such as `@hlv:artifact code-auth implements spec-auth` in owned code/test/doc files.
+5. Run `hlv artifacts audit`.
+6. Use `hlv artifacts impact <id-or-path>`, `hlv artifacts impact --changed` locally, or `hlv artifacts impact --changed --base <target-branch>` in PR review.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -629,3 +629,5 @@ To adopt the feature gradually:
 4. Add file-level markers such as `@hlv:artifact code-auth implements spec-auth` in owned code/test/doc files.
 5. Run `hlv artifacts audit`.
 6. Use `hlv artifacts impact <id-or-path>`, `hlv artifacts impact --changed` locally, or `hlv artifacts impact --changed --base <target-branch>` in PR review.
+
+For CI usage of `--base`, ensure the checkout has enough history to compute a merge base. With GitHub Actions, fetch the target branch explicitly or use `actions/checkout` with `fetch-depth: 0`.

--- a/schema/project-schema.json
+++ b/schema/project-schema.json
@@ -66,6 +66,9 @@
     },
     "features": {
       "$ref": "#/$defs/Features"
+    },
+    "artifact_graph": {
+      "$ref": "#/$defs/ArtifactGraphConfig"
     }
   },
   "additionalProperties": false,
@@ -244,6 +247,60 @@
           "type": "boolean",
           "default": true,
           "description": "Enable @hlv:sec security attention markers and SEC-010 diagnostic"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ArtifactGraphConfig": {
+      "type": "object",
+      "description": "Artifact dependency graph configuration. Artifact-local links live in Markdown frontmatter; path-based code ownership lives here.",
+      "properties": {
+        "code_ownership": {
+          "type": "object",
+          "default": {},
+          "additionalProperties": { "$ref": "#/$defs/CodeOwnershipEntry" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "CodeOwnershipEntry": {
+      "type": "object",
+      "properties": {
+        "paths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        },
+        "owners": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        },
+        "requires": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        },
+        "depends_on": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Alias for requires."
+        },
+        "implements": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        },
+        "verifies": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
+        },
+        "documents": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": []
         }
       },
       "additionalProperties": false

--- a/skills/generate/SKILL.md
+++ b/skills/generate/SKILL.md
@@ -80,8 +80,9 @@ From all artifacts, extract:
 1. **Domain entities** — types, enums, relationships → update `glossary.yaml` (schema: `schema/glossary-schema.json`)
 2. **Capabilities** — what the system must do → future contracts
 3. **Tech stack** — languages, frameworks, databases, infra → `stack` section in project.yaml
-4. **Constraints** — NFR, security, compliance → constraints
-5. **Open questions** — information that cannot be derived from context → `open-questions.md`
+4. **Artifact graph metadata** — stable artifact IDs, owners, and relations (`requires`/`depends_on`, `implements`, `verifies`, `documents`, `supersedes`, `conflicts_with`, `affects`). Add YAML frontmatter to generated/updated Markdown artifacts when the relation is known.
+5. **Constraints** — NFR, security, compliance → constraints
+6. **Open questions** — information that cannot be derived from context → `open-questions.md`
 
 ### Step 3: Generate contracts
 
@@ -344,6 +345,10 @@ Update `project.yaml` (schema: `schema/project-schema.json`) with stack info if 
             type: framework
   ```
   Valid component types: `service`, `library`, `cli`, `worker`, `database`, `cache`, `queue`, `gateway`. Valid dependency types: `framework`, `library`, `runtime`, `tool`.
+
+Also update `project.yaml -> artifact_graph.code_ownership` when generated code/test/doc ownership can be inferred from contracts, plans, or explicit artifact text. Keep document-to-document relations in Markdown frontmatter; keep path-based code ownership in `project.yaml`.
+
+After adding or changing artifact frontmatter, run `hlv artifacts sync` to materialize missing `code-*`, `tests-*`, `docs-*`, and `clients-*` ownership stubs in `project.yaml`, then fill concrete paths when they are known.
 
 ### Step 9: Output summary
 

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -119,6 +119,8 @@ validation/
 7. Update stage status → `implementing` in `milestones.yaml` (schema: `schema/milestones-schema.json`)
 8. Read `{MID}/stage_N.md` — load tasks for the current stage
 9. Read `project.yaml → stack.components` — understand target languages, frameworks
+10. Read `project.yaml → artifact_graph.code_ownership` when present. New or changed implementation/test/doc paths must preserve ownership mappings and relation fields (`implements`, `verifies`, `documents`, `requires`) so `hlv artifacts impact` can route downstream review.
+11. For every new or changed file under an artifact ownership path, add file-level evidence markers for the relevant relation, e.g. `@hlv:artifact code-auth implements spec-auth`, `@hlv:artifact tests-auth verifies spec-auth`, or `@hlv:artifact docs-auth documents spec-auth`. Use the native comment syntax for the file type.
 
 ### Step 2: Execute tasks
 

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -58,6 +58,8 @@ human/
 
 Note: `project.yaml → stack` provides tech stack context (languages, frameworks, databases) which can inform gate execution — e.g., choosing the correct test runner, SAST tool, or dependency scanner per component.
 
+Note: `project.yaml → artifact_graph` and artifact frontmatter provide impact-analysis context. Before validating a PR-like change, run `hlv artifacts impact --changed --base <target-branch>` (or `hlv artifacts impact --changed` for local worktree review) and ensure every downstream item has an explicit review disposition outside HLV (`updated`, `reviewed-ok`, `deferred`, `obsolete`, or `unknown`). Treat missing dispositions as a review blocker even when deterministic gates pass.
+
 ## Steps
 
 ### Step 1: Pre-flight and gate status

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -58,7 +58,7 @@ human/
 
 Note: `project.yaml → stack` provides tech stack context (languages, frameworks, databases) which can inform gate execution — e.g., choosing the correct test runner, SAST tool, or dependency scanner per component.
 
-Note: `project.yaml → artifact_graph` and artifact frontmatter provide impact-analysis context. Before validating a PR-like change, run `hlv artifacts impact --changed --base <target-branch>` (or `hlv artifacts impact --changed` for local worktree review) and ensure every downstream item has an explicit review disposition outside HLV (`updated`, `reviewed-ok`, `deferred`, `obsolete`, or `unknown`). Treat missing dispositions as a review blocker even when deterministic gates pass.
+Note: `project.yaml → artifact_graph` and artifact frontmatter provide impact-analysis context. Before validating a PR-like change, run `hlv artifacts impact --changed --base <target-branch>` (or `hlv artifacts impact --changed` for local worktree review) and ensure every downstream item has an explicit review disposition outside HLV (`updated`, `reviewed-ok`, `deferred`, `obsolete`, or `unknown`). In CI, make sure the checkout can compute a merge base by fetching the target branch or using sufficient history such as `actions/checkout` with `fetch-depth: 0`. Treat missing dispositions as a review blocker even when deterministic gates pass.
 
 ## Steps
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -93,8 +93,10 @@ For the traceability file (`{MID}/traceability.yaml`):
 #### 1d. Artifact dependency graph
 
 - [ ] Markdown artifact frontmatter IDs are stable and unique
+- [ ] HLV artifact frontmatter includes both `id` and `type`; legacy non-HLV frontmatter without both keys is ignored
 - [ ] Every artifact graph node has `owners`
 - [ ] `depends_on`/`requires`, `implements`, `verifies`, `documents`, `supersedes`, `conflicts_with`, and `affects` point to existing IDs
+- [ ] Run `hlv artifacts graph` when reviewing impact metadata to inspect all nodes and relations together
 - [ ] Run `hlv artifacts sync --check`; if it reports missing ownership stubs, run `hlv artifacts sync` and fill paths where known
 - [ ] Owned code/test/doc paths with declared relations include `@hlv:artifact <node-id> <relation> <artifact-id>` markers, or `ART-050` is explicitly accepted as a warning during migration
 - [ ] Accepted ADRs affect an architecture node or have an explicit review note

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -90,6 +90,16 @@ For the traceability file (`{MID}/traceability.yaml`):
 - [ ] No dangling references (all IDs exist)
 - [ ] No artifacts without coverage by any REQ (warning)
 
+#### 1d. Artifact dependency graph
+
+- [ ] Markdown artifact frontmatter IDs are stable and unique
+- [ ] Every artifact graph node has `owners`
+- [ ] `depends_on`/`requires`, `implements`, `verifies`, `documents`, `supersedes`, `conflicts_with`, and `affects` point to existing IDs
+- [ ] Run `hlv artifacts sync --check`; if it reports missing ownership stubs, run `hlv artifacts sync` and fill paths where known
+- [ ] Owned code/test/doc paths with declared relations include `@hlv:artifact <node-id> <relation> <artifact-id>` markers, or `ART-050` is explicitly accepted as a warning during migration
+- [ ] Accepted ADRs affect an architecture node or have an explicit review note
+- [ ] Run `hlv artifacts audit`; fix `ART-*` errors before marking the stage verified
+
 #### 1d. Plan structure
 
 For `{MID}/plan.md` (overview) and `{MID}/stage_N.md` files:

--- a/src/check/artifacts.rs
+++ b/src/check/artifacts.rs
@@ -1,0 +1,248 @@
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use regex::Regex;
+
+use crate::check::Diagnostic;
+use crate::model::artifact::ArtifactGraph;
+use crate::model::milestone::MilestoneMap;
+use crate::model::project::ProjectMap;
+
+pub fn check_artifacts(root: &Path, project: &ProjectMap) -> Vec<Diagnostic> {
+    let milestone_id = current_milestone_id(root);
+    let graph = match ArtifactGraph::load(root, project, milestone_id.as_deref()) {
+        Ok(graph) => graph,
+        Err(e) => {
+            return vec![Diagnostic::error(
+                "ART-001",
+                format!("Cannot parse artifact graph: {}", e),
+            )];
+        }
+    };
+
+    let mut diags = Vec::new();
+    let ids: BTreeSet<&str> = graph.nodes.keys().map(String::as_str).collect();
+
+    for node in graph.nodes.values() {
+        let file = node
+            .path
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| "project.yaml".to_string());
+
+        if node.owners.is_empty() {
+            diags.push(
+                Diagnostic::warning("ART-010", format!("Artifact '{}' has no owners", node.id))
+                    .with_file(&file),
+            );
+        }
+
+        for relation in &node.relations {
+            if !ids.contains(relation.target.as_str()) {
+                diags.push(
+                    Diagnostic::error(
+                        "ART-020",
+                        format!(
+                            "Artifact '{}' has dangling {} reference '{}'",
+                            node.id, relation.kind, relation.target
+                        ),
+                    )
+                    .with_file(&file),
+                );
+            }
+        }
+
+        if node.artifact_type == "adr"
+            && node.status.as_deref() == Some("accepted")
+            && !node.relations.iter().any(|r| {
+                r.kind == "affects"
+                    && graph
+                        .nodes
+                        .get(&r.target)
+                        .map(|target| target.artifact_type == "architecture")
+                        .unwrap_or(false)
+            })
+        {
+            diags.push(
+                Diagnostic::warning(
+                    "ART-030",
+                    format!(
+                        "Accepted ADR '{}' should affect an architecture artifact or be reviewed explicitly",
+                        node.id
+                    ),
+                )
+                .with_file(&file),
+            );
+        }
+
+        for conflict in node.relations.iter().filter(|r| r.kind == "conflicts_with") {
+            if let Some(other) = graph.nodes.get(&conflict.target) {
+                if node.status.as_deref() == Some("accepted")
+                    && other.status.as_deref() == Some("accepted")
+                {
+                    diags.push(
+                        Diagnostic::error(
+                            "ART-040",
+                            format!(
+                                "Accepted artifact '{}' conflicts with accepted artifact '{}'",
+                                node.id, other.id
+                            ),
+                        )
+                        .with_file(&file),
+                    );
+                }
+            }
+        }
+    }
+
+    diags.extend(check_artifact_markers(root, project));
+
+    diags
+}
+
+fn check_artifact_markers(root: &Path, project: &ProjectMap) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+    let Some(config) = &project.artifact_graph else {
+        return diags;
+    };
+
+    for (node_id, entry) in &config.code_ownership {
+        if entry.paths.is_empty() {
+            continue;
+        }
+
+        let files = collect_owned_files(root, &entry.paths);
+        if files.is_empty() {
+            continue;
+        }
+
+        let markers = scan_artifact_markers(&files);
+        for (relation, target) in expected_marker_relations(entry) {
+            if !markers.iter().any(|marker| {
+                marker.node_id == *node_id
+                    && marker.relation == relation
+                    && marker.artifact_id == *target
+            }) {
+                diags.push(Diagnostic::warning(
+                    "ART-050",
+                    format!(
+                        "Ownership node '{}' {} '{}' but no @hlv:artifact marker found in owned paths",
+                        node_id, relation, target
+                    ),
+                ));
+            }
+        }
+    }
+
+    diags
+}
+
+fn expected_marker_relations(
+    entry: &crate::model::project::CodeOwnershipEntry,
+) -> Vec<(&'static str, &String)> {
+    let mut expected = Vec::new();
+    for target in &entry.requires {
+        expected.push(("requires", target));
+    }
+    for target in &entry.depends_on {
+        expected.push(("requires", target));
+    }
+    for target in &entry.implements {
+        expected.push(("implements", target));
+    }
+    for target in &entry.verifies {
+        expected.push(("verifies", target));
+    }
+    for target in &entry.documents {
+        expected.push(("documents", target));
+    }
+    expected
+}
+
+#[derive(Debug)]
+struct ArtifactMarker {
+    node_id: String,
+    relation: String,
+    artifact_id: String,
+}
+
+fn scan_artifact_markers(files: &[PathBuf]) -> Vec<ArtifactMarker> {
+    let re = Regex::new(r"@hlv:artifact\s+(\S+)\s+(\S+)\s+(\S+)").expect("valid regex");
+    let mut markers = Vec::new();
+    for file in files {
+        let content = match std::fs::read_to_string(file) {
+            Ok(content) => content,
+            Err(_) => continue,
+        };
+        for line in content.lines() {
+            for cap in re.captures_iter(line) {
+                markers.push(ArtifactMarker {
+                    node_id: cap[1].to_string(),
+                    relation: cap[2].to_string(),
+                    artifact_id: cap[3].to_string(),
+                });
+            }
+        }
+    }
+    markers
+}
+
+fn collect_owned_files(root: &Path, patterns: &[String]) -> Vec<PathBuf> {
+    let mut files = BTreeSet::new();
+    for pattern in patterns {
+        if let Some(dir_pattern) = pattern.strip_suffix("/**") {
+            let dir = root.join(dir_pattern);
+            if dir.is_dir() {
+                collect_files_recursive(&dir, &mut files);
+                continue;
+            }
+        }
+
+        let full = root.join(pattern);
+        if full.is_file() {
+            files.insert(full);
+            continue;
+        }
+        if full.is_dir() {
+            collect_files_recursive(&full, &mut files);
+            continue;
+        }
+
+        let glob_pattern = full.to_string_lossy().to_string();
+        if let Ok(paths) = glob::glob(&glob_pattern) {
+            for path in paths.flatten().filter(|path| path.is_file()) {
+                files.insert(path);
+            }
+        }
+    }
+    files.into_iter().collect()
+}
+
+fn collect_files_recursive(dir: &Path, files: &mut BTreeSet<PathBuf>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name().to_string_lossy().to_string();
+        if path.is_dir() {
+            if matches!(name.as_str(), ".git" | "target" | "node_modules") {
+                continue;
+            }
+            collect_files_recursive(&path, files);
+        } else if path.is_file() {
+            files.insert(path);
+        }
+    }
+}
+
+fn current_milestone_id(root: &Path) -> Option<String> {
+    let path = root.join("milestones.yaml");
+    if !path.exists() {
+        return None;
+    }
+    MilestoneMap::load(&path)
+        .ok()
+        .and_then(|m| m.current.map(|c| c.id))
+}

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -1,3 +1,4 @@
+pub mod artifacts;
 pub mod code_trace;
 pub mod constraints;
 pub mod contracts;

--- a/src/cmd/artifacts.rs
+++ b/src/cmd/artifacts.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::style;
 use crate::check::{self, Severity};
-use crate::model::artifact::{ArtifactFull, ArtifactGraph, ArtifactIndex};
+use crate::model::artifact::{ArtifactFull, ArtifactGraph, ArtifactIndex, ArtifactNode};
 use crate::model::milestone::MilestoneMap;
 use crate::model::project::{ArtifactGraphConfig, CodeOwnershipEntry, ProjectMap};
 
@@ -195,6 +195,72 @@ pub fn run_impact(
             println!("    via: {}", item.via.join(", "));
         }
     }
+    Ok(())
+}
+
+/// `hlv artifacts graph [--json]`
+pub fn run_graph(root: &Path, json: bool) -> Result<()> {
+    let project = ProjectMap::load(&root.join("project.yaml"))?;
+    let milestone_id = current_milestone_id(root);
+    let graph = ArtifactGraph::load(root, &project, milestone_id.as_deref())?;
+    let report = ArtifactGraphReport::from_graph(&graph);
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    style::header("artifact graph");
+    if report.nodes.is_empty() {
+        style::hint("No artifact graph metadata found.");
+        return Ok(());
+    }
+
+    style::section("Nodes");
+    for node in &report.nodes {
+        let location = node
+            .path
+            .as_ref()
+            .map(|path| path.display().to_string())
+            .or_else(|| {
+                if node.paths.is_empty() {
+                    None
+                } else {
+                    Some(node.paths.join(", "))
+                }
+            })
+            .map(|location| format!(" {}", location.dimmed()))
+            .unwrap_or_default();
+        let owners = if node.owners.is_empty() {
+            "owners: unknown".to_string()
+        } else {
+            format!("owners: {}", node.owners.join(", "))
+        };
+        println!(
+            "  {} {} ({}){} — {}",
+            "·".dimmed(),
+            node.id.bold(),
+            node.artifact_type,
+            location,
+            owners
+        );
+    }
+
+    style::section("Relations");
+    if report.edges.is_empty() {
+        style::ok("no relations");
+    } else {
+        for edge in &report.edges {
+            println!(
+                "  {} {} --{}--> {}",
+                "·".dimmed(),
+                edge.source.bold(),
+                edge.relation,
+                edge.target.bold()
+            );
+        }
+    }
+
     Ok(())
 }
 
@@ -492,6 +558,40 @@ fn parse_git_status_path(line: &str) -> Option<&str> {
         return None;
     }
     Some(path.rsplit_once(" -> ").map(|(_, new)| new).unwrap_or(path))
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ArtifactGraphReport {
+    nodes: Vec<ArtifactNode>,
+    edges: Vec<ArtifactGraphEdge>,
+}
+
+impl ArtifactGraphReport {
+    fn from_graph(graph: &ArtifactGraph) -> Self {
+        let nodes: Vec<ArtifactNode> = graph.nodes.values().cloned().collect();
+        let edges = graph
+            .nodes
+            .values()
+            .flat_map(|node| {
+                node.relations
+                    .iter()
+                    .map(move |relation| ArtifactGraphEdge {
+                        source: node.id.clone(),
+                        relation: relation.kind.clone(),
+                        target: relation.target.clone(),
+                    })
+            })
+            .collect();
+
+        Self { nodes, edges }
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+struct ArtifactGraphEdge {
+    source: String,
+    relation: String,
+    target: String,
 }
 
 #[derive(Debug, serde::Serialize)]

--- a/src/cmd/artifacts.rs
+++ b/src/cmd/artifacts.rs
@@ -404,7 +404,10 @@ fn changed_paths(root: &Path, base: Option<&str>) -> Result<std::collections::BT
             .with_context(|| format!("Cannot run git merge-base {base} HEAD"))?;
         if !merge_base.status.success() {
             let stderr = String::from_utf8_lossy(&merge_base.stderr);
-            anyhow::bail!("git merge-base failed: {}", stderr.trim());
+            anyhow::bail!(
+                "git merge-base failed: {}. If this is a shallow CI checkout, fetch the base ref first or use actions/checkout with fetch-depth: 0.",
+                stderr.trim()
+            );
         }
         let merge_base = String::from_utf8_lossy(&merge_base.stdout)
             .trim()

--- a/src/cmd/artifacts.rs
+++ b/src/cmd/artifacts.rs
@@ -3,8 +3,10 @@ use colored::Colorize;
 use std::path::Path;
 
 use super::style;
-use crate::model::artifact::{ArtifactFull, ArtifactIndex};
+use crate::check::{self, Severity};
+use crate::model::artifact::{ArtifactFull, ArtifactGraph, ArtifactIndex};
 use crate::model::milestone::MilestoneMap;
+use crate::model::project::{ArtifactGraphConfig, CodeOwnershipEntry, ProjectMap};
 
 /// `hlv artifacts [--global | --milestone] [--json]`
 pub fn run_list(root: &Path, global_only: bool, milestone_only: bool, json: bool) -> Result<()> {
@@ -131,6 +133,202 @@ pub fn get_artifact_show(
     }
 }
 
+/// `hlv artifacts impact <id-or-path> [--json]`
+pub fn run_impact(
+    root: &Path,
+    target: Option<&str>,
+    changed: bool,
+    base: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let project = ProjectMap::load(&root.join("project.yaml"))?;
+    let milestone_id = current_milestone_id(root);
+    let graph = ArtifactGraph::load(root, &project, milestone_id.as_deref())?;
+    let changed_ids = if changed {
+        changed_artifact_ids(root, &graph, base)?
+    } else {
+        vec![resolve_artifact_target(
+            root,
+            &graph,
+            target.context("Artifact id or path required")?,
+        )?]
+    };
+
+    let report = graph.impact(&changed_ids);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    style::header("artifact impact");
+    if report.changed.is_empty() {
+        style::hint("No changed artifacts found.");
+        return Ok(());
+    }
+    style::section("Changed");
+    for id in &report.changed {
+        println!("  {} {}", "·".dimmed(), id.bold());
+    }
+    style::section("Expected to review");
+    if report.affected.is_empty() {
+        style::ok("no downstream artifacts");
+    } else {
+        for item in &report.affected {
+            let path = item
+                .path
+                .as_ref()
+                .map(|p| format!(" {}", p.display().to_string().dimmed()))
+                .unwrap_or_default();
+            let owners = if item.owners.is_empty() {
+                "owners: unknown".to_string()
+            } else {
+                format!("owners: {}", item.owners.join(", "))
+            };
+            println!(
+                "  {} {} ({}){} — {}",
+                "·".dimmed(),
+                item.id.bold(),
+                item.artifact_type,
+                path,
+                owners
+            );
+            println!("    via: {}", item.via.join(", "));
+        }
+    }
+    Ok(())
+}
+
+/// `hlv artifacts audit [--json]`
+pub fn run_audit(root: &Path, json: bool) -> Result<()> {
+    let project = ProjectMap::load(&root.join("project.yaml"))?;
+    let milestone_id = current_milestone_id(root);
+    let graph = ArtifactGraph::load(root, &project, milestone_id.as_deref());
+    let diags = check::artifacts::check_artifacts(root, &project);
+    let exit_code = check::exit_code(&diags);
+    let errors = diags
+        .iter()
+        .filter(|d| matches!(d.severity, Severity::Error))
+        .count();
+    let warnings = diags
+        .iter()
+        .filter(|d| matches!(d.severity, Severity::Warning))
+        .count();
+    let metadata_found = graph
+        .as_ref()
+        .map(|graph| !graph.nodes.is_empty())
+        .unwrap_or(true);
+    if json {
+        let output = serde_json::json!({
+            "metadata_found": metadata_found,
+            "errors": errors,
+            "warnings": warnings,
+            "exit_code": exit_code,
+            "diagnostics": diags,
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        if exit_code != 0 {
+            std::process::exit(exit_code);
+        }
+        return Ok(());
+    }
+    style::header("artifact audit");
+    if !metadata_found {
+        style::hint(
+            "No artifact graph metadata found. Existing projects are compatible; add artifact frontmatter and project.yaml -> artifact_graph.code_ownership when you want impact analysis.",
+        );
+        return Ok(());
+    }
+    if diags.is_empty() {
+        style::ok("artifact graph checks passed");
+    } else {
+        for diag in &diags {
+            diag.print();
+        }
+    }
+    if exit_code != 0 {
+        std::process::exit(exit_code);
+    }
+    Ok(())
+}
+
+/// `hlv artifacts sync [--check] [--json]`
+pub fn run_sync(root: &Path, check: bool, json: bool) -> Result<()> {
+    let project_path = root.join("project.yaml");
+    let mut project = ProjectMap::load(&project_path)?;
+    let milestone_id = current_milestone_id(root);
+    let graph = ArtifactGraph::load(root, &project, milestone_id.as_deref())?;
+    let missing = missing_ownership_targets(&graph);
+
+    if !check && !missing.is_empty() {
+        let config = project
+            .artifact_graph
+            .get_or_insert_with(|| ArtifactGraphConfig {
+                code_ownership: Default::default(),
+            });
+        for target in &missing {
+            config
+                .code_ownership
+                .entry(target.id.clone())
+                .or_insert_with(|| CodeOwnershipEntry {
+                    paths: Vec::new(),
+                    owners: target.owners.clone(),
+                    requires: Vec::new(),
+                    implements: Vec::new(),
+                    verifies: Vec::new(),
+                    documents: Vec::new(),
+                    depends_on: Vec::new(),
+                });
+        }
+        project.save(&project_path)?;
+    }
+
+    if json {
+        let output = serde_json::json!({
+            "changed": !check && !missing.is_empty(),
+            "check": check,
+            "missing": missing,
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+        if check && !output["missing"].as_array().unwrap().is_empty() {
+            std::process::exit(1);
+        }
+        return Ok(());
+    }
+
+    style::header("artifact sync");
+    if missing.is_empty() {
+        style::ok("project.yaml artifact_graph is in sync");
+        return Ok(());
+    }
+
+    if check {
+        for target in &missing {
+            println!(
+                "  {} {} referenced by {} needs project.yaml -> artifact_graph.code_ownership entry",
+                "!".yellow().bold(),
+                target.id.bold(),
+                target.referenced_by.join(", ")
+            );
+        }
+        std::process::exit(1);
+    }
+
+    for target in &missing {
+        println!(
+            "  {} added {} (owners: {})",
+            "+".green().bold(),
+            target.id.bold(),
+            if target.owners.is_empty() {
+                "unknown".to_string()
+            } else {
+                target.owners.join(", ")
+            }
+        );
+    }
+    style::hint("Add concrete paths under each new code_ownership entry before relying on path-based routing.");
+    Ok(())
+}
+
 fn find_artifact(
     root: &Path,
     name: &str,
@@ -157,6 +355,181 @@ fn current_milestone_id(root: &Path) -> Option<String> {
     MilestoneMap::load(&path)
         .ok()
         .and_then(|m| m.current.map(|c| c.id))
+}
+
+fn resolve_artifact_target(root: &Path, graph: &ArtifactGraph, target: &str) -> Result<String> {
+    if graph.nodes.contains_key(target) {
+        return Ok(target.to_string());
+    }
+    let target_path = root.join(target);
+    let normalized = target_path.strip_prefix(root).unwrap_or(&target_path);
+    let normalized = normalize_relative_path(normalized);
+    for node in graph.nodes.values() {
+        if node
+            .path
+            .as_ref()
+            .map(|p| normalize_relative_path(p) == normalized)
+            .unwrap_or(false)
+            || node
+                .paths
+                .iter()
+                .any(|pattern| path_matches_pattern(&normalized, pattern))
+        {
+            return Ok(node.id.clone());
+        }
+    }
+    anyhow::bail!("Unknown artifact id or path '{}'", target);
+}
+
+fn changed_artifact_ids(
+    root: &Path,
+    graph: &ArtifactGraph,
+    base: Option<&str>,
+) -> Result<Vec<String>> {
+    let changed_paths = changed_paths(root, base)?;
+    Ok(graph
+        .nodes
+        .values()
+        .filter(|node| node_matches_changed_paths(node, &changed_paths))
+        .map(|node| node.id.clone())
+        .collect())
+}
+
+fn changed_paths(root: &Path, base: Option<&str>) -> Result<std::collections::BTreeSet<String>> {
+    if let Some(base) = base {
+        let merge_base = std::process::Command::new("git")
+            .args(["merge-base", base, "HEAD"])
+            .current_dir(root)
+            .output()
+            .with_context(|| format!("Cannot run git merge-base {base} HEAD"))?;
+        if !merge_base.status.success() {
+            let stderr = String::from_utf8_lossy(&merge_base.stderr);
+            anyhow::bail!("git merge-base failed: {}", stderr.trim());
+        }
+        let merge_base = String::from_utf8_lossy(&merge_base.stdout)
+            .trim()
+            .to_string();
+        let output = std::process::Command::new("git")
+            .args(["diff", "--name-only", &merge_base, "HEAD"])
+            .current_dir(root)
+            .output()
+            .with_context(|| format!("Cannot run git diff --name-only {merge_base} HEAD"))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("git diff failed: {}", stderr.trim());
+        }
+        return Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(str::to_string)
+            .collect());
+    }
+
+    let output = std::process::Command::new("git")
+        .args(["status", "--porcelain=v1", "--untracked-files=all"])
+        .current_dir(root)
+        .output()
+        .context("Cannot run git status --porcelain")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git status failed: {}", stderr.trim());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(parse_git_status_path)
+        .map(str::to_string)
+        .collect())
+}
+
+fn node_matches_changed_paths(
+    node: &crate::model::artifact::ArtifactNode,
+    changed_paths: &std::collections::BTreeSet<String>,
+) -> bool {
+    if node
+        .path
+        .as_ref()
+        .map(|p| changed_paths.contains(&normalize_relative_path(p)))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    changed_paths.iter().any(|changed_path| {
+        node.paths
+            .iter()
+            .any(|pattern| path_matches_pattern(changed_path, pattern))
+    })
+}
+
+fn normalize_relative_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .trim_start_matches("./")
+        .replace('\\', "/")
+}
+
+fn path_matches_pattern(path: &str, pattern: &str) -> bool {
+    let pattern = pattern.trim_start_matches("./");
+    if path == pattern {
+        return true;
+    }
+    if let Some(dir) = pattern.strip_suffix("/**") {
+        return path == dir || path.starts_with(&format!("{dir}/"));
+    }
+    glob::Pattern::new(pattern)
+        .map(|pattern| pattern.matches(path))
+        .unwrap_or(false)
+}
+
+fn parse_git_status_path(line: &str) -> Option<&str> {
+    if line.len() < 4 {
+        return None;
+    }
+    let path = line[3..].trim();
+    if path.is_empty() {
+        return None;
+    }
+    Some(path.rsplit_once(" -> ").map(|(_, new)| new).unwrap_or(path))
+}
+
+#[derive(Debug, serde::Serialize)]
+struct SyncTarget {
+    id: String,
+    owners: Vec<String>,
+    referenced_by: Vec<String>,
+}
+
+fn missing_ownership_targets(graph: &ArtifactGraph) -> Vec<SyncTarget> {
+    let mut targets: std::collections::BTreeMap<String, SyncTarget> =
+        std::collections::BTreeMap::new();
+    for node in graph.nodes.values().filter(|node| node.path.is_some()) {
+        for relation in &node.relations {
+            if graph.nodes.contains_key(&relation.target) || !is_ownership_target(&relation.target)
+            {
+                continue;
+            }
+            let target = targets
+                .entry(relation.target.clone())
+                .or_insert_with(|| SyncTarget {
+                    id: relation.target.clone(),
+                    owners: node.owners.clone(),
+                    referenced_by: Vec::new(),
+                });
+            if target.owners.is_empty() && !node.owners.is_empty() {
+                target.owners = node.owners.clone();
+            }
+            if !target.referenced_by.iter().any(|id| id == &node.id) {
+                target.referenced_by.push(node.id.clone());
+            }
+        }
+    }
+    targets.into_values().collect()
+}
+
+fn is_ownership_target(id: &str) -> bool {
+    id.starts_with("code-")
+        || id.starts_with("tests-")
+        || id.starts_with("docs-")
+        || id.starts_with("clients-")
 }
 
 // Display for ArtifactKind

--- a/src/cmd/check.rs
+++ b/src/cmd/check.rs
@@ -121,6 +121,8 @@ pub fn get_check_diagnostics(root: &Path) -> Result<(Vec<Diagnostic>, i32)> {
         all_diags.extend(check::stack::check_stack(stack));
     }
 
+    all_diags.extend(check::artifacts::check_artifacts(root, &project));
+
     {
         let tests_path = project.paths.llm.tests.as_deref();
         all_diags.extend(check::code_trace::check_code_trace(
@@ -330,6 +332,11 @@ fn run_checks(root: &Path) -> Result<i32> {
         print_diags(&stack_diags);
         all_diags.extend(stack_diags);
     }
+
+    style::section("Artifacts");
+    let artifact_diags = check::artifacts::check_artifacts(root, &project);
+    print_diags(&artifact_diags);
+    all_diags.extend(artifact_diags);
 
     // 7. Code traceability (@hlv markers)
     {

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -720,6 +720,9 @@ features:
   hlv_markers: {hlv_markers}
   security_markers: {security_markers}
 
+artifact_graph:
+  code_ownership: {{}}
+
 git:
   branch_per_milestone: false
   commit_convention: conventional

--- a/src/main.rs
+++ b/src/main.rs
@@ -307,6 +307,35 @@ enum ArtifactsAction {
         #[arg(long)]
         json: bool,
     },
+    /// Show downstream impact for an artifact id/path or current git diff
+    Impact {
+        /// Artifact id or path. Omit with --changed to inspect git diff.
+        target: Option<String>,
+        /// Use changed artifact files from git worktree status, or from --base when provided
+        #[arg(long)]
+        changed: bool,
+        /// Compare committed PR changes against the merge-base of this ref and HEAD
+        #[arg(long)]
+        base: Option<String>,
+        /// Output in JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Audit artifact graph metadata and references
+    Audit {
+        /// Output in JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Sync project.yaml code ownership stubs from artifact frontmatter
+    Sync {
+        /// Check only; exit non-zero if sync would add entries
+        #[arg(long)]
+        check: bool,
+        /// Output in JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -806,6 +835,24 @@ fn run(cli: Cli) -> Result<()> {
                 m || milestone,
                 j || json,
             ),
+            Some(ArtifactsAction::Impact {
+                target,
+                changed,
+                base,
+                json: j,
+            }) => hlv::cmd::artifacts::run_impact(
+                &project_root,
+                target.as_deref(),
+                changed,
+                base.as_deref(),
+                j || json,
+            ),
+            Some(ArtifactsAction::Audit { json: j }) => {
+                hlv::cmd::artifacts::run_audit(&project_root, j || json)
+            }
+            Some(ArtifactsAction::Sync { check, json: j }) => {
+                hlv::cmd::artifacts::run_sync(&project_root, check, j || json)
+            }
         },
         Commands::Mcp { .. } => unreachable!(),
         Commands::Update { .. } => unreachable!(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,6 +321,12 @@ enum ArtifactsAction {
         #[arg(long)]
         json: bool,
     },
+    /// Show the full artifact dependency graph
+    Graph {
+        /// Output in JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Audit artifact graph metadata and references
     Audit {
         /// Output in JSON
@@ -847,6 +853,9 @@ fn run(cli: Cli) -> Result<()> {
                 base.as_deref(),
                 j || json,
             ),
+            Some(ArtifactsAction::Graph { json: j }) => {
+                hlv::cmd::artifacts::run_graph(&project_root, j || json)
+            }
             Some(ArtifactsAction::Audit { json: j }) => {
                 hlv::cmd::artifacts::run_audit(&project_root, j || json)
             }

--- a/src/model/artifact.rs
+++ b/src/model/artifact.rs
@@ -311,23 +311,29 @@ fn scan_artifacts_dir(dir: &Path) -> Result<Vec<ArtifactMeta>> {
 }
 
 pub fn parse_frontmatter(content: &str) -> Result<Option<ArtifactFrontmatter>> {
-    let Some(rest) = content
-        .strip_prefix("---\n")
-        .or_else(|| content.strip_prefix("---\r\n"))
-    else {
+    let mut lines = content.lines();
+    let Some(first) = lines.next() else {
         return Ok(None);
     };
-    let Some((yaml, _body)) = rest
-        .split_once("\n---")
-        .or_else(|| rest.split_once("\r\n---"))
-    else {
-        return Ok(None);
-    };
-    if !looks_like_hlv_frontmatter(yaml)? {
+    if first.trim_end_matches('\r') != "---" {
         return Ok(None);
     }
-    let meta: ArtifactFrontmatter = serde_yaml::from_str(yaml)?;
-    Ok(Some(meta))
+
+    let mut yaml_lines = Vec::new();
+    for line in lines {
+        let line = line.trim_end_matches('\r');
+        if line == "---" {
+            let yaml = yaml_lines.join("\n");
+            if !looks_like_hlv_frontmatter(&yaml)? {
+                return Ok(None);
+            }
+            let meta: ArtifactFrontmatter = serde_yaml::from_str(&yaml)?;
+            return Ok(Some(meta));
+        }
+        yaml_lines.push(line);
+    }
+
+    Ok(None)
 }
 
 fn looks_like_hlv_frontmatter(yaml: &str) -> Result<bool> {

--- a/src/model/artifact.rs
+++ b/src/model/artifact.rs
@@ -1,6 +1,9 @@
-use anyhow::Result;
-use serde::Serialize;
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
+
+use crate::model::project::ProjectMap;
 
 /// Kind of artifact based on filename
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -36,6 +39,76 @@ pub struct ArtifactFull {
 pub struct ArtifactIndex {
     pub global: Vec<ArtifactMeta>,
     pub milestone: Vec<ArtifactMeta>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactFrontmatter {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub artifact_type: String,
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub owners: Vec<String>,
+    #[serde(default)]
+    pub owns: Option<String>,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    #[serde(default)]
+    pub affects: Vec<String>,
+    #[serde(default)]
+    pub requires: Vec<String>,
+    #[serde(default)]
+    pub implements: Vec<String>,
+    #[serde(default)]
+    pub verifies: Vec<String>,
+    #[serde(default)]
+    pub documents: Vec<String>,
+    #[serde(default)]
+    pub supersedes: Vec<String>,
+    #[serde(default)]
+    pub conflicts_with: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ArtifactNode {
+    pub id: String,
+    pub artifact_type: String,
+    pub path: Option<PathBuf>,
+    #[serde(default)]
+    pub paths: Vec<String>,
+    pub owners: Vec<String>,
+    pub status: Option<String>,
+    pub owns: Option<String>,
+    pub relations: Vec<ArtifactRelation>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ArtifactRelation {
+    pub kind: String,
+    pub target: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImpactItem {
+    pub id: String,
+    pub artifact_type: String,
+    pub path: Option<PathBuf>,
+    pub paths: Vec<String>,
+    pub owners: Vec<String>,
+    pub via: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ImpactReport {
+    pub changed: Vec<String>,
+    pub affected: Vec<ImpactItem>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ArtifactGraph {
+    pub nodes: BTreeMap<String, ArtifactNode>,
 }
 
 impl ArtifactIndex {
@@ -80,6 +153,142 @@ impl ArtifactFull {
     }
 }
 
+impl ArtifactGraph {
+    pub fn load(root: &Path, project: &ProjectMap, milestone_id: Option<&str>) -> Result<Self> {
+        let mut nodes = BTreeMap::new();
+        let mut sources = BTreeMap::new();
+        for path in artifact_markdown_paths(root, project, milestone_id)? {
+            let content = std::fs::read_to_string(&path)?;
+            if let Some(frontmatter) = parse_frontmatter(&content)? {
+                let id = frontmatter.id.clone();
+                let source = path
+                    .strip_prefix(root)
+                    .ok()
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .to_string();
+                let relations = relations_from_frontmatter(&frontmatter);
+                insert_node(
+                    &mut nodes,
+                    &mut sources,
+                    &id,
+                    &source,
+                    ArtifactNode {
+                        id: frontmatter.id,
+                        artifact_type: frontmatter.artifact_type,
+                        path: path.strip_prefix(root).ok().map(Path::to_path_buf),
+                        paths: Vec::new(),
+                        owners: frontmatter.owners,
+                        status: frontmatter.status,
+                        owns: frontmatter.owns,
+                        relations,
+                    },
+                )?;
+            }
+        }
+
+        if let Some(config) = &project.artifact_graph {
+            for (id, entry) in &config.code_ownership {
+                let mut relations = Vec::new();
+                push_relations(&mut relations, "requires", &entry.requires);
+                push_relations(&mut relations, "requires", &entry.depends_on);
+                push_relations(&mut relations, "implements", &entry.implements);
+                push_relations(&mut relations, "verifies", &entry.verifies);
+                push_relations(&mut relations, "documents", &entry.documents);
+                let source = format!("project.yaml -> artifact_graph.code_ownership.{id}");
+                insert_node(
+                    &mut nodes,
+                    &mut sources,
+                    id,
+                    &source,
+                    ArtifactNode {
+                        id: id.clone(),
+                        artifact_type: "code".to_string(),
+                        path: None,
+                        paths: entry.paths.clone(),
+                        owners: entry.owners.clone(),
+                        status: None,
+                        owns: Some(entry.paths.join(", ")),
+                        relations,
+                    },
+                )?;
+            }
+        }
+
+        Ok(Self { nodes })
+    }
+
+    pub fn impact(&self, changed: &[String]) -> ImpactReport {
+        let mut affected: BTreeMap<String, ImpactItem> = BTreeMap::new();
+        let changed_set: BTreeSet<&str> = changed.iter().map(String::as_str).collect();
+
+        for changed_id in changed {
+            if let Some(changed_node) = self.nodes.get(changed_id) {
+                for relation in changed_node
+                    .relations
+                    .iter()
+                    .filter(|r| r.kind == "affects" && !changed_set.contains(r.target.as_str()))
+                {
+                    self.add_impact(&mut affected, &relation.target, "affects");
+                }
+            }
+
+            for node in self.nodes.values() {
+                if changed_set.contains(node.id.as_str()) {
+                    continue;
+                }
+                for relation in node.relations.iter().filter(|r| &r.target == changed_id) {
+                    let via = format!("{}:{}", relation.kind, changed_id);
+                    self.add_impact(&mut affected, &node.id, &via);
+                }
+            }
+        }
+
+        ImpactReport {
+            changed: changed.to_vec(),
+            affected: affected.into_values().collect(),
+        }
+    }
+
+    fn add_impact(&self, affected: &mut BTreeMap<String, ImpactItem>, id: &str, via: &str) {
+        if let Some(node) = self.nodes.get(id) {
+            let item = affected
+                .entry(id.to_string())
+                .or_insert_with(|| ImpactItem {
+                    id: node.id.clone(),
+                    artifact_type: node.artifact_type.clone(),
+                    path: node.path.clone(),
+                    paths: node.paths.clone(),
+                    owners: node.owners.clone(),
+                    via: Vec::new(),
+                });
+            if !item.via.iter().any(|v| v == via) {
+                item.via.push(via.to_string());
+            }
+        }
+    }
+}
+
+fn insert_node(
+    nodes: &mut BTreeMap<String, ArtifactNode>,
+    sources: &mut BTreeMap<String, String>,
+    id: &str,
+    source: &str,
+    node: ArtifactNode,
+) -> Result<()> {
+    if let Some(previous) = sources.get(id) {
+        bail!(
+            "Duplicate artifact id '{}' in {} and {}",
+            id,
+            previous,
+            source
+        );
+    }
+    sources.insert(id.to_string(), source.to_string());
+    nodes.insert(id.to_string(), node);
+    Ok(())
+}
+
 fn scan_artifacts_dir(dir: &Path) -> Result<Vec<ArtifactMeta>> {
     if !dir.exists() {
         return Ok(Vec::new());
@@ -99,6 +308,115 @@ fn scan_artifacts_dir(dir: &Path) -> Result<Vec<ArtifactMeta>> {
     }
     result.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(result)
+}
+
+pub fn parse_frontmatter(content: &str) -> Result<Option<ArtifactFrontmatter>> {
+    let Some(rest) = content
+        .strip_prefix("---\n")
+        .or_else(|| content.strip_prefix("---\r\n"))
+    else {
+        return Ok(None);
+    };
+    let Some((yaml, _body)) = rest
+        .split_once("\n---")
+        .or_else(|| rest.split_once("\r\n---"))
+    else {
+        return Ok(None);
+    };
+    if !looks_like_hlv_frontmatter(yaml)? {
+        return Ok(None);
+    }
+    let meta: ArtifactFrontmatter = serde_yaml::from_str(yaml)?;
+    Ok(Some(meta))
+}
+
+fn looks_like_hlv_frontmatter(yaml: &str) -> Result<bool> {
+    let value: serde_yaml::Value = serde_yaml::from_str(yaml)?;
+    let Some(mapping) = value.as_mapping() else {
+        return Ok(false);
+    };
+    let has_key = |key: &str| {
+        mapping
+            .keys()
+            .any(|k| k.as_str().map(|s| s == key).unwrap_or(false))
+    };
+    let relation_keys = [
+        "depends_on",
+        "affects",
+        "requires",
+        "implements",
+        "verifies",
+        "documents",
+        "supersedes",
+        "conflicts_with",
+    ];
+    let has_relation = relation_keys.iter().any(|key| has_key(key));
+    let has_hlv_identity = has_key("id")
+        && (has_key("type") || has_key("owners") || has_key("owns") || has_key("status"));
+    Ok(has_hlv_identity || has_relation)
+}
+
+fn relations_from_frontmatter(frontmatter: &ArtifactFrontmatter) -> Vec<ArtifactRelation> {
+    let mut relations = Vec::new();
+    push_relations(&mut relations, "requires", &frontmatter.depends_on);
+    push_relations(&mut relations, "requires", &frontmatter.requires);
+    push_relations(&mut relations, "implements", &frontmatter.implements);
+    push_relations(&mut relations, "verifies", &frontmatter.verifies);
+    push_relations(&mut relations, "documents", &frontmatter.documents);
+    push_relations(&mut relations, "supersedes", &frontmatter.supersedes);
+    push_relations(
+        &mut relations,
+        "conflicts_with",
+        &frontmatter.conflicts_with,
+    );
+    push_relations(&mut relations, "affects", &frontmatter.affects);
+    relations
+}
+
+fn push_relations(relations: &mut Vec<ArtifactRelation>, kind: &str, targets: &[String]) {
+    for target in targets {
+        relations.push(ArtifactRelation {
+            kind: kind.to_string(),
+            target: target.clone(),
+        });
+    }
+}
+
+fn artifact_markdown_paths(
+    root: &Path,
+    project: &ProjectMap,
+    milestone_id: Option<&str>,
+) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    if let Some(global) = project.paths.human.artifacts.as_deref() {
+        collect_md_recursive(&root.join(global), &mut paths)?;
+    } else {
+        collect_md_recursive(&root.join("human/artifacts"), &mut paths)?;
+    }
+    if let Some(mid) = milestone_id {
+        collect_md_recursive(
+            &root.join("human/milestones").join(mid).join("artifacts"),
+            &mut paths,
+        )?;
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+fn collect_md_recursive(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_md_recursive(&path, out)?;
+        } else if path.extension().map(|e| e == "md").unwrap_or(false) {
+            out.push(path);
+        }
+    }
+    Ok(())
 }
 
 fn classify_artifact(name: &str) -> ArtifactKind {
@@ -154,6 +472,49 @@ mod tests {
         assert_eq!(full.name, "context");
         assert_eq!(full.kind, ArtifactKind::Context);
         assert!(full.content.contains("Some content"));
+    }
+
+    #[test]
+    fn parse_artifact_frontmatter() {
+        let content = r#"---
+id: adr-auth-session
+type: adr
+status: accepted
+owners: [platform]
+depends_on:
+  - spec-auth
+affects:
+  - code-auth-session
+---
+# ADR
+"#;
+        let meta = parse_frontmatter(content).unwrap().unwrap();
+        assert_eq!(meta.id, "adr-auth-session");
+        assert_eq!(meta.artifact_type, "adr");
+        assert_eq!(meta.owners, vec!["platform"]);
+        assert_eq!(meta.depends_on, vec!["spec-auth"]);
+        assert_eq!(meta.affects, vec!["code-auth-session"]);
+    }
+
+    #[test]
+    fn parse_artifact_frontmatter_with_crlf() {
+        let content = "---\r\nid: spec-checkout\r\ntype: spec\r\nowners: [product]\r\naffects: [code-checkout]\r\n---\r\n# Spec\r\n";
+        let meta = parse_frontmatter(content).unwrap().unwrap();
+        assert_eq!(meta.id, "spec-checkout");
+        assert_eq!(meta.artifact_type, "spec");
+        assert_eq!(meta.affects, vec!["code-checkout"]);
+    }
+
+    #[test]
+    fn legacy_markdown_frontmatter_is_ignored() {
+        let content = r#"---
+title: Auth Notes
+date: 2026-01-01
+tags: [auth]
+---
+# Notes
+"#;
+        assert!(parse_frontmatter(content).unwrap().is_none());
     }
 
     #[test]

--- a/src/model/artifact.rs
+++ b/src/model/artifact.rs
@@ -203,7 +203,7 @@ impl ArtifactGraph {
                     &source,
                     ArtifactNode {
                         id: id.clone(),
-                        artifact_type: "code".to_string(),
+                        artifact_type: ownership_artifact_type(id).to_string(),
                         path: None,
                         paths: entry.paths.clone(),
                         owners: entry.owners.clone(),
@@ -346,20 +346,19 @@ fn looks_like_hlv_frontmatter(yaml: &str) -> Result<bool> {
             .keys()
             .any(|k| k.as_str().map(|s| s == key).unwrap_or(false))
     };
-    let relation_keys = [
-        "depends_on",
-        "affects",
-        "requires",
-        "implements",
-        "verifies",
-        "documents",
-        "supersedes",
-        "conflicts_with",
-    ];
-    let has_relation = relation_keys.iter().any(|key| has_key(key));
-    let has_hlv_identity = has_key("id")
-        && (has_key("type") || has_key("owners") || has_key("owns") || has_key("status"));
-    Ok(has_hlv_identity || has_relation)
+    Ok(has_key("id") && has_key("type"))
+}
+
+fn ownership_artifact_type(id: &str) -> &str {
+    if id.starts_with("tests-") {
+        "tests"
+    } else if id.starts_with("docs-") {
+        "docs"
+    } else if id.starts_with("clients-") {
+        "clients"
+    } else {
+        "code"
+    }
 }
 
 fn relations_from_frontmatter(frontmatter: &ArtifactFrontmatter) -> Vec<ArtifactRelation> {
@@ -521,6 +520,26 @@ tags: [auth]
 # Notes
 "#;
         assert!(parse_frontmatter(content).unwrap().is_none());
+    }
+
+    #[test]
+    fn legacy_id_status_frontmatter_is_ignored() {
+        let content = r#"---
+id: adr-auth-session
+status: accepted
+---
+# ADR
+"#;
+        assert!(parse_frontmatter(content).unwrap().is_none());
+    }
+
+    #[test]
+    fn ownership_artifact_type_uses_id_prefix() {
+        assert_eq!(ownership_artifact_type("code-auth"), "code");
+        assert_eq!(ownership_artifact_type("tests-auth"), "tests");
+        assert_eq!(ownership_artifact_type("docs-auth"), "docs");
+        assert_eq!(ownership_artifact_type("clients-auth"), "clients");
+        assert_eq!(ownership_artifact_type("auth"), "code");
     }
 
     #[test]

--- a/src/model/project.rs
+++ b/src/model/project.rs
@@ -29,6 +29,36 @@ pub struct ProjectMap {
     pub git: GitPolicy,
     #[serde(default)]
     pub features: Features,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_graph: Option<ArtifactGraphConfig>,
+}
+
+// ── Artifact Dependency Graph ─────────────────────────
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactGraphConfig {
+    #[serde(default)]
+    pub code_ownership: std::collections::BTreeMap<String, CodeOwnershipEntry>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
+pub struct CodeOwnershipEntry {
+    #[serde(default)]
+    pub paths: Vec<String>,
+    #[serde(default)]
+    pub owners: Vec<String>,
+    #[serde(default)]
+    pub requires: Vec<String>,
+    #[serde(default)]
+    pub implements: Vec<String>,
+    #[serde(default)]
+    pub verifies: Vec<String>,
+    #[serde(default)]
+    pub documents: Vec<String>,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
 }
 
 // ── Features ────────────────────────────────────────────
@@ -549,6 +579,7 @@ type: some_new_type
             stack: None,
             git: GitPolicy::default(),
             features: Features::default(),
+            artifact_graph: None,
         };
 
         pm.save(&path).unwrap();
@@ -593,6 +624,7 @@ type: some_new_type
             stack: None,
             git: GitPolicy::default(),
             features: Features::default(),
+            artifact_graph: None,
         };
 
         pm.add_constraint(ConstraintEntry {
@@ -730,7 +762,7 @@ custom_field: hello
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("project.yaml");
 
-        let mut pm = ProjectMap {
+        let pm = ProjectMap {
             schema_version: 1,
             project: "test-features".to_string(),
             spec: None,
@@ -767,6 +799,7 @@ custom_field: hello
                 hlv_markers: false,
                 security_markers: true,
             },
+            artifact_graph: None,
         };
 
         pm.save(&path).unwrap();

--- a/src/parse/markdown.rs
+++ b/src/parse/markdown.rs
@@ -74,11 +74,10 @@ pub fn extract_sections(md: &str) -> Vec<Section> {
                     current_body.push_str(&text);
                 }
             }
-            Event::SoftBreak | Event::HardBreak => {
-                if !in_heading {
-                    current_body.push('\n');
-                }
+            Event::SoftBreak | Event::HardBreak if !in_heading => {
+                current_body.push('\n');
             }
+            Event::SoftBreak | Event::HardBreak => {}
             Event::Start(Tag::CodeBlock(kind)) => {
                 let lang = match &kind {
                     pulldown_cmark::CodeBlockKind::Fenced(lang) => lang.to_string(),

--- a/tests/artifacts_tests.rs
+++ b/tests/artifacts_tests.rs
@@ -81,6 +81,40 @@ fn artifacts_audit_json_legacy_project_smoke() {
 }
 
 #[test]
+fn artifacts_audit_ignores_legacy_id_status_frontmatter_smoke() {
+    let tmp = TempDir::new().unwrap();
+    setup_legacy_project(tmp.path());
+
+    std::fs::write(
+        tmp.path().join("human/artifacts/legacy-adr.md"),
+        r#"---
+id: adr-auth-session
+status: accepted
+---
+# ADR
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(hlv_bin())
+        .args(["--root", tmp.path().to_str().unwrap(), "artifacts", "audit"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "legacy id/status frontmatter should be ignored: stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("ART-001"),
+        "legacy frontmatter should not emit ART-001: {stdout}"
+    );
+}
+
+#[test]
 fn artifacts_audit_errors_exit_nonzero_smoke() {
     let tmp = TempDir::new().unwrap();
     setup_legacy_project(tmp.path());
@@ -169,6 +203,91 @@ fn artifacts_impact_fixture_smoke() {
     assert!(stdout.contains("Expected to review"));
     assert!(stdout.contains("code-checkout"));
     assert!(stdout.contains("tests-checkout"));
+}
+
+#[test]
+fn artifacts_impact_json_reports_ownership_types_smoke() {
+    let output = Command::new(hlv_bin())
+        .args([
+            "--root",
+            "tests/fixtures/example-project",
+            "artifacts",
+            "impact",
+            "spec-checkout",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "impact --json should pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let affected = value["affected"].as_array().unwrap();
+    assert!(affected
+        .iter()
+        .any(|item| item["id"] == "code-checkout" && item["artifact_type"] == "code"));
+    assert!(affected
+        .iter()
+        .any(|item| item["id"] == "tests-checkout" && item["artifact_type"] == "tests"));
+}
+
+#[test]
+fn artifacts_graph_fixture_smoke() {
+    let output = Command::new(hlv_bin())
+        .args([
+            "--root",
+            "tests/fixtures/example-project",
+            "artifacts",
+            "graph",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "graph should pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("artifact graph"));
+    assert!(stdout.contains("spec-checkout (spec)"));
+    assert!(stdout.contains("spec-checkout --affects--> code-checkout"));
+    assert!(stdout.contains("code-checkout --implements--> spec-checkout"));
+    assert!(stdout.contains("tests-checkout --verifies--> spec-checkout"));
+}
+
+#[test]
+fn artifacts_graph_json_fixture_smoke() {
+    let output = Command::new(hlv_bin())
+        .args([
+            "--root",
+            "tests/fixtures/example-project",
+            "artifacts",
+            "graph",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "graph --json should pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(value["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|node| node["id"] == "spec-checkout"));
+    assert!(value["edges"].as_array().unwrap().iter().any(|edge| {
+        edge["source"] == "code-checkout"
+            && edge["relation"] == "implements"
+            && edge["target"] == "spec-checkout"
+    }));
 }
 
 #[test]

--- a/tests/artifacts_tests.rs
+++ b/tests/artifacts_tests.rs
@@ -1,0 +1,481 @@
+use std::process::Command;
+
+use tempfile::TempDir;
+
+fn hlv_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_hlv")
+}
+
+fn setup_legacy_project(root: &std::path::Path) {
+    hlv::cmd::init::run_with_milestone(
+        root.to_str().unwrap(),
+        Some("legacy-project"),
+        Some("platform"),
+        Some("claude"),
+        Some("init"),
+        Some("minimal"),
+    )
+    .unwrap();
+}
+
+fn git(root: &std::path::Path, args: &[&str]) {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "git {:?} failed\nstdout: {}\nstderr: {}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn artifacts_audit_legacy_project_smoke() {
+    let tmp = TempDir::new().unwrap();
+    setup_legacy_project(tmp.path());
+
+    let output = Command::new(hlv_bin())
+        .args(["--root", tmp.path().to_str().unwrap(), "artifacts", "audit"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "audit should pass for legacy projects: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("No artifact graph metadata found"),
+        "expected legacy migration hint, got: {stdout}"
+    );
+}
+
+#[test]
+fn artifacts_audit_json_legacy_project_smoke() {
+    let tmp = TempDir::new().unwrap();
+    setup_legacy_project(tmp.path());
+
+    let output = Command::new(hlv_bin())
+        .args([
+            "--root",
+            tmp.path().to_str().unwrap(),
+            "artifacts",
+            "audit",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["metadata_found"], false);
+    assert_eq!(value["errors"], 0);
+    assert_eq!(value["warnings"], 0);
+    assert_eq!(value["exit_code"], 0);
+    assert_eq!(value["diagnostics"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn artifacts_audit_errors_exit_nonzero_smoke() {
+    let tmp = TempDir::new().unwrap();
+    setup_legacy_project(tmp.path());
+
+    std::fs::write(
+        tmp.path().join("human/artifacts/spec-auth.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+depends_on: [missing-adr]
+---
+# Auth Spec
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(hlv_bin())
+        .args(["--root", tmp.path().to_str().unwrap(), "artifacts", "audit"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "audit should fail on ART errors");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("ART-020"), "expected ART-020: {stdout}");
+}
+
+#[test]
+fn artifacts_audit_json_errors_include_counts_smoke() {
+    let tmp = TempDir::new().unwrap();
+    setup_legacy_project(tmp.path());
+
+    std::fs::write(
+        tmp.path().join("human/artifacts/spec-auth.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+depends_on: [missing-adr]
+---
+# Auth Spec
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(hlv_bin())
+        .args([
+            "--root",
+            tmp.path().to_str().unwrap(),
+            "artifacts",
+            "audit",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        !output.status.success(),
+        "audit --json should fail on ART errors"
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["errors"], 1);
+    assert_eq!(value["exit_code"], 1);
+    assert_eq!(value["diagnostics"][0]["code"], "ART-020");
+}
+
+#[test]
+fn artifacts_impact_fixture_smoke() {
+    let output = Command::new(hlv_bin())
+        .args([
+            "--root",
+            "tests/fixtures/example-project",
+            "artifacts",
+            "impact",
+            "spec-checkout",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "impact should pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Expected to review"));
+    assert!(stdout.contains("code-checkout"));
+    assert!(stdout.contains("tests-checkout"));
+}
+
+#[test]
+fn artifacts_impact_changed_without_head_smoke() {
+    let tmp = TempDir::new().unwrap();
+    setup_legacy_project(tmp.path());
+
+    let git = Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    assert!(
+        git.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&git.stderr)
+    );
+
+    std::fs::write(
+        tmp.path().join("human/artifacts/spec-auth.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+affects: [code-auth]
+---
+# Auth Spec
+"#,
+    )
+    .unwrap();
+
+    let project_path = tmp.path().join("project.yaml");
+    let mut project = std::fs::read_to_string(&project_path).unwrap();
+    project = project.replace(
+        "  code_ownership: {}\n",
+        r#"
+  code_ownership:
+    code-auth:
+      paths: [llm/src/auth/**]
+      owners: [platform]
+      implements: [spec-auth]
+"#,
+    );
+    std::fs::write(project_path, project).unwrap();
+
+    let output = Command::new(hlv_bin())
+        .args([
+            "--root",
+            tmp.path().to_str().unwrap(),
+            "artifacts",
+            "impact",
+            "--changed",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "impact --changed should not require HEAD: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("spec-auth"),
+        "expected changed artifact: {stdout}"
+    );
+    assert!(
+        stdout.contains("code-auth"),
+        "expected affected code node: {stdout}"
+    );
+}
+
+#[test]
+fn artifacts_impact_changed_matches_code_ownership_paths_smoke() {
+    let tmp = TempDir::new().unwrap();
+    setup_legacy_project(tmp.path());
+    git(tmp.path(), &["init"]);
+    git(tmp.path(), &["config", "user.email", "hlv@example.com"]);
+    git(tmp.path(), &["config", "user.name", "HLV Test"]);
+
+    std::fs::write(
+        tmp.path().join("human/artifacts/spec-auth.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+affects: [code-auth]
+---
+# Auth Spec
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("llm/src/auth")).unwrap();
+    std::fs::write(
+        tmp.path().join("llm/src/auth/service.ts"),
+        "// @hlv:artifact code-auth implements spec-auth\nexport class Auth {}\n",
+    )
+    .unwrap();
+
+    let project_path = tmp.path().join("project.yaml");
+    let mut project = std::fs::read_to_string(&project_path).unwrap();
+    project = project.replace(
+        "  code_ownership: {}\n",
+        r#"
+  code_ownership:
+    code-auth:
+      paths: [llm/src/auth/**]
+      owners: [platform]
+      implements: [spec-auth]
+"#,
+    );
+    std::fs::write(project_path, project).unwrap();
+    git(tmp.path(), &["add", "."]);
+    git(tmp.path(), &["commit", "-m", "base"]);
+
+    std::fs::write(
+        tmp.path().join("llm/src/auth/service.ts"),
+        "// @hlv:artifact code-auth implements spec-auth\nexport class Auth { login() {} }\n",
+    )
+    .unwrap();
+
+    let output = Command::new(hlv_bin())
+        .args([
+            "--root",
+            tmp.path().to_str().unwrap(),
+            "artifacts",
+            "impact",
+            "--changed",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "impact --changed should pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["changed"], serde_json::json!(["code-auth"]));
+}
+
+#[test]
+fn artifacts_impact_changed_base_uses_merge_base_smoke() {
+    let tmp = TempDir::new().unwrap();
+    setup_legacy_project(tmp.path());
+    git(tmp.path(), &["init"]);
+    git(tmp.path(), &["config", "user.email", "hlv@example.com"]);
+    git(tmp.path(), &["config", "user.name", "HLV Test"]);
+
+    std::fs::write(
+        tmp.path().join("human/artifacts/spec-auth.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+affects: [code-auth]
+---
+# Auth Spec
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir_all(tmp.path().join("llm/src/auth")).unwrap();
+    std::fs::write(
+        tmp.path().join("llm/src/auth/service.ts"),
+        "// @hlv:artifact code-auth implements spec-auth\nexport class Auth {}\n",
+    )
+    .unwrap();
+    let project_path = tmp.path().join("project.yaml");
+    let mut project = std::fs::read_to_string(&project_path).unwrap();
+    project = project.replace(
+        "  code_ownership: {}\n",
+        r#"
+  code_ownership:
+    code-auth:
+      paths: [llm/src/auth/**]
+      owners: [platform]
+      implements: [spec-auth]
+"#,
+    );
+    std::fs::write(project_path, project).unwrap();
+    git(tmp.path(), &["add", "."]);
+    git(tmp.path(), &["commit", "-m", "base"]);
+
+    std::fs::write(
+        tmp.path().join("llm/src/auth/service.ts"),
+        "// @hlv:artifact code-auth implements spec-auth\nexport class Auth { login() {} }\n",
+    )
+    .unwrap();
+    git(tmp.path(), &["add", "."]);
+    git(tmp.path(), &["commit", "-m", "change auth"]);
+
+    let output = Command::new(hlv_bin())
+        .args([
+            "--root",
+            tmp.path().to_str().unwrap(),
+            "artifacts",
+            "impact",
+            "--changed",
+            "--base",
+            "HEAD~1",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "impact --changed --base should pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["changed"], serde_json::json!(["code-auth"]));
+}
+
+#[test]
+fn artifacts_impact_unknown_target_fails_smoke() {
+    let output = Command::new(hlv_bin())
+        .args([
+            "--root",
+            "tests/fixtures/example-project",
+            "artifacts",
+            "impact",
+            "missing-artifact",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "unknown target should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Unknown artifact id or path 'missing-artifact'"),
+        "expected unknown-target error: {stderr}"
+    );
+}
+
+#[test]
+fn artifacts_sync_creates_ownership_stubs_smoke() {
+    let tmp = TempDir::new().unwrap();
+    setup_legacy_project(tmp.path());
+
+    std::fs::write(
+        tmp.path().join("human/artifacts/spec-auth.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+affects:
+  - code-auth
+  - tests-auth
+---
+# Auth Spec
+"#,
+    )
+    .unwrap();
+
+    let check = Command::new(hlv_bin())
+        .args([
+            "--root",
+            tmp.path().to_str().unwrap(),
+            "artifacts",
+            "sync",
+            "--check",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        !check.status.success(),
+        "sync --check should fail when stubs are missing"
+    );
+
+    let output = Command::new(hlv_bin())
+        .args([
+            "--root",
+            tmp.path().to_str().unwrap(),
+            "artifacts",
+            "sync",
+            "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "sync should pass: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["changed"], true);
+    assert_eq!(value["missing"].as_array().unwrap().len(), 2);
+
+    let project = hlv::model::project::ProjectMap::load(&tmp.path().join("project.yaml")).unwrap();
+    let ownership = &project
+        .artifact_graph
+        .expect("artifact_graph")
+        .code_ownership;
+    assert!(ownership.contains_key("code-auth"));
+    assert!(ownership.contains_key("tests-auth"));
+    assert_eq!(ownership["code-auth"].owners, vec!["product"]);
+
+    let audit = Command::new(hlv_bin())
+        .args(["--root", tmp.path().to_str().unwrap(), "artifacts", "audit"])
+        .output()
+        .unwrap();
+    assert!(
+        audit.status.success(),
+        "audit should pass after sync: {}",
+        String::from_utf8_lossy(&audit.stderr)
+    );
+}

--- a/tests/check_tests.rs
+++ b/tests/check_tests.rs
@@ -1867,6 +1867,11 @@ fn init_creates_scaffold() {
     .unwrap();
 
     assert!(tmp.path().join("project.yaml").exists());
+    let project = hlv::model::project::ProjectMap::load(&tmp.path().join("project.yaml")).unwrap();
+    let artifact_graph = project
+        .artifact_graph
+        .expect("new projects should include artifact_graph");
+    assert!(artifact_graph.code_ownership.is_empty());
     assert!(tmp.path().join("milestones.yaml").exists());
     assert!(tmp.path().join("HLV.md").exists());
     assert!(tmp.path().join("AGENTS.md").exists());
@@ -3906,6 +3911,7 @@ fn minimal_project_with_constraints(
         stack: None,
         git: Default::default(),
         features: Default::default(),
+        artifact_graph: None,
     }
 }
 
@@ -4111,4 +4117,342 @@ fn sec_markers_disabled_returns_empty() {
 
     let diags = check_sec_markers(root, "llm/src", false);
     assert!(diags.is_empty(), "disabled = no diagnostics: {:?}", diags);
+}
+
+// ═══════════════════════════════════════════════════════
+// ART-010 / ART-020 / ART-030: artifact graph checks
+// ═══════════════════════════════════════════════════════
+
+#[test]
+fn artifact_graph_valid_passes() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("human/artifacts")).unwrap();
+    fs::write(
+        root.join("human/artifacts/spec.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+affects: [code-auth]
+---
+# Spec
+"#,
+    )
+    .unwrap();
+
+    let mut project = minimal_project_with_constraints(vec![]);
+    project.artifact_graph = Some(hlv::model::project::ArtifactGraphConfig {
+        code_ownership: [(
+            "code-auth".to_string(),
+            hlv::model::project::CodeOwnershipEntry {
+                paths: vec!["llm/src/auth/**".to_string()],
+                owners: vec!["platform".to_string()],
+                implements: vec!["spec-auth".to_string()],
+                requires: vec![],
+                verifies: vec![],
+                documents: vec![],
+                depends_on: vec![],
+            },
+        )]
+        .into_iter()
+        .collect(),
+    });
+
+    let diags = hlv::check::artifacts::check_artifacts(root, &project);
+    assert!(!has_any_error(&diags), "unexpected errors: {:?}", diags);
+    assert!(
+        !has_warning(&diags, "ART-010"),
+        "unexpected owner warning: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn artifact_graph_absent_legacy_project_passes() {
+    let tmp = TempDir::new().unwrap();
+    let project = minimal_project_with_constraints(vec![]);
+
+    let diags = hlv::check::artifacts::check_artifacts(tmp.path(), &project);
+    assert!(
+        diags.is_empty(),
+        "legacy project should not require graph metadata: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn artifact_graph_dangling_reference_errors() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("human/artifacts")).unwrap();
+    fs::write(
+        root.join("human/artifacts/spec.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+depends_on: [missing-adr]
+---
+# Spec
+"#,
+    )
+    .unwrap();
+
+    let project = minimal_project_with_constraints(vec![]);
+    let diags = hlv::check::artifacts::check_artifacts(root, &project);
+    assert!(
+        has_error(&diags, "ART-020"),
+        "expected ART-020: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn accepted_adr_without_architecture_link_warns() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("human/artifacts")).unwrap();
+    fs::write(
+        root.join("human/artifacts/adr.md"),
+        r#"---
+id: adr-auth
+type: adr
+status: accepted
+owners: [platform]
+---
+# ADR
+"#,
+    )
+    .unwrap();
+
+    let project = minimal_project_with_constraints(vec![]);
+    let diags = hlv::check::artifacts::check_artifacts(root, &project);
+    assert!(
+        has_warning(&diags, "ART-030"),
+        "expected ART-030: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn accepted_adr_with_architecture_type_link_passes_for_non_prefixed_id() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("human/artifacts")).unwrap();
+    fs::write(
+        root.join("human/artifacts/adr.md"),
+        r#"---
+id: adr-auth
+type: adr
+status: accepted
+owners: [platform]
+affects: [arch-auth]
+---
+# ADR
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("human/artifacts/arch.md"),
+        r#"---
+id: arch-auth
+type: architecture
+owners: [platform]
+---
+# Architecture
+"#,
+    )
+    .unwrap();
+
+    let project = minimal_project_with_constraints(vec![]);
+    let diags = hlv::check::artifacts::check_artifacts(root, &project);
+    assert!(
+        !has_warning(&diags, "ART-030"),
+        "unexpected ART-030: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn duplicate_artifact_ids_error() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("human/artifacts")).unwrap();
+    fs::write(
+        root.join("human/artifacts/spec-a.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+---
+# Spec A
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("human/artifacts/spec-b.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+---
+# Spec B
+"#,
+    )
+    .unwrap();
+
+    let project = minimal_project_with_constraints(vec![]);
+    let diags = hlv::check::artifacts::check_artifacts(root, &project);
+    assert!(
+        has_error(&diags, "ART-001"),
+        "expected duplicate-id ART-001: {:?}",
+        diags
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.message.contains("Duplicate artifact id 'spec-auth'")),
+        "expected duplicate-id message: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn duplicate_artifact_id_between_markdown_and_code_ownership_errors() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("human/artifacts")).unwrap();
+    fs::write(
+        root.join("human/artifacts/spec.md"),
+        r#"---
+id: code-auth
+type: spec
+owners: [product]
+---
+# Spec
+"#,
+    )
+    .unwrap();
+
+    let mut project = minimal_project_with_constraints(vec![]);
+    project.artifact_graph = Some(hlv::model::project::ArtifactGraphConfig {
+        code_ownership: [(
+            "code-auth".to_string(),
+            hlv::model::project::CodeOwnershipEntry {
+                paths: vec!["llm/src/auth/**".to_string()],
+                owners: vec!["platform".to_string()],
+                implements: vec![],
+                requires: vec![],
+                verifies: vec![],
+                documents: vec![],
+                depends_on: vec![],
+            },
+        )]
+        .into_iter()
+        .collect(),
+    });
+
+    let diags = hlv::check::artifacts::check_artifacts(root, &project);
+    assert!(
+        has_error(&diags, "ART-001"),
+        "expected duplicate-id ART-001: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn artifact_marker_missing_warns() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("human/artifacts")).unwrap();
+    fs::create_dir_all(root.join("llm/src/auth")).unwrap();
+    fs::write(
+        root.join("human/artifacts/spec.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+affects: [code-auth]
+---
+# Spec
+"#,
+    )
+    .unwrap();
+    fs::write(root.join("llm/src/auth/service.rs"), "pub struct Auth;\n").unwrap();
+
+    let mut project = minimal_project_with_constraints(vec![]);
+    project.artifact_graph = Some(hlv::model::project::ArtifactGraphConfig {
+        code_ownership: [(
+            "code-auth".to_string(),
+            hlv::model::project::CodeOwnershipEntry {
+                paths: vec!["llm/src/auth/**".to_string()],
+                owners: vec!["platform".to_string()],
+                implements: vec!["spec-auth".to_string()],
+                requires: vec![],
+                verifies: vec![],
+                documents: vec![],
+                depends_on: vec![],
+            },
+        )]
+        .into_iter()
+        .collect(),
+    });
+
+    let diags = hlv::check::artifacts::check_artifacts(root, &project);
+    assert!(
+        has_warning(&diags, "ART-050"),
+        "expected ART-050: {:?}",
+        diags
+    );
+}
+
+#[test]
+fn artifact_marker_present_passes() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    fs::create_dir_all(root.join("human/artifacts")).unwrap();
+    fs::create_dir_all(root.join("llm/src/auth")).unwrap();
+    fs::write(
+        root.join("human/artifacts/spec.md"),
+        r#"---
+id: spec-auth
+type: spec
+owners: [product]
+affects: [code-auth]
+---
+# Spec
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("llm/src/auth/service.ts"),
+        "// @hlv:artifact code-auth implements spec-auth\nexport class Auth {}\n",
+    )
+    .unwrap();
+
+    let mut project = minimal_project_with_constraints(vec![]);
+    project.artifact_graph = Some(hlv::model::project::ArtifactGraphConfig {
+        code_ownership: [(
+            "code-auth".to_string(),
+            hlv::model::project::CodeOwnershipEntry {
+                paths: vec!["llm/src/auth/**".to_string()],
+                owners: vec!["platform".to_string()],
+                implements: vec!["spec-auth".to_string()],
+                requires: vec![],
+                verifies: vec![],
+                documents: vec![],
+                depends_on: vec![],
+            },
+        )]
+        .into_iter()
+        .collect(),
+    });
+
+    let diags = hlv::check::artifacts::check_artifacts(root, &project);
+    assert!(
+        !has_warning(&diags, "ART-050"),
+        "unexpected ART-050: {:?}",
+        diags
+    );
 }

--- a/tests/fixtures/example-project/human/artifacts/adr-checkout-consistency.md
+++ b/tests/fixtures/example-project/human/artifacts/adr-checkout-consistency.md
@@ -1,0 +1,14 @@
+---
+id: adr-checkout-consistency
+type: adr
+status: accepted
+owners: [backend]
+depends_on:
+  - spec-checkout
+affects:
+  - architecture-checkout
+  - code-checkout
+---
+# Checkout Consistency ADR
+
+Use optimistic consistency checks for checkout writes.

--- a/tests/fixtures/example-project/human/artifacts/architecture-checkout.md
+++ b/tests/fixtures/example-project/human/artifacts/architecture-checkout.md
@@ -1,0 +1,11 @@
+---
+id: architecture-checkout
+type: architecture
+status: accepted
+owners: [platform]
+documents:
+  - adr-checkout-consistency
+---
+# Checkout Architecture
+
+Checkout is owned by the backend service.

--- a/tests/fixtures/example-project/human/artifacts/spec-checkout.md
+++ b/tests/fixtures/example-project/human/artifacts/spec-checkout.md
@@ -1,0 +1,13 @@
+---
+id: spec-checkout
+type: spec
+status: accepted
+owners: [product]
+affects:
+  - code-checkout
+  - tests-checkout
+  - architecture-checkout
+---
+# Checkout Spec
+
+The checkout flow creates orders from carts and preserves consistency.

--- a/tests/fixtures/example-project/llm/map.yaml
+++ b/tests/fixtures/example-project/llm/map.yaml
@@ -16,6 +16,18 @@ entries:
     kind: dir
     layer: human
     description: "Global project context (domain, stack, arch decisions)"
+  - path: human/artifacts/spec-checkout.md
+    kind: file
+    layer: human
+    description: "Checkout specification artifact with dependency graph metadata"
+  - path: human/artifacts/adr-checkout-consistency.md
+    kind: file
+    layer: human
+    description: "Checkout consistency ADR with dependency graph metadata"
+  - path: human/artifacts/architecture-checkout.md
+    kind: file
+    layer: human
+    description: "Checkout architecture artifact linked from accepted ADR"
 
   # --- Human Layer: Glossary ---
   - path: human/glossary.yaml

--- a/tests/fixtures/example-project/project.yaml
+++ b/tests/fixtures/example-project/project.yaml
@@ -100,6 +100,22 @@ features:
   hlv_markers: true
   security_markers: true
 
+artifact_graph:
+  code_ownership:
+    code-checkout:
+      paths:
+        - llm/src/**
+      owners: [backend]
+      implements:
+        - spec-checkout
+        - adr-checkout-consistency
+    tests-checkout:
+      paths:
+        - llm/tests/**
+      owners: [qa]
+      verifies:
+        - spec-checkout
+
 # --- Validation State ---
 
 validation:

--- a/tests/model_parse.rs
+++ b/tests/model_parse.rs
@@ -30,6 +30,21 @@ fn parse_features_with_security_markers() {
 }
 
 #[test]
+fn parse_project_yaml_artifact_graph() {
+    let p = ProjectMap::load(&Path::new(FIXTURE).join("project.yaml")).unwrap();
+    let graph = p.artifact_graph.expect("artifact_graph should be present");
+    let code = graph
+        .code_ownership
+        .get("code-checkout")
+        .expect("code ownership");
+    assert_eq!(code.paths, vec!["llm/src/**"]);
+    assert_eq!(
+        code.implements,
+        vec!["spec-checkout", "adr-checkout-consistency"]
+    );
+}
+
+#[test]
 fn features_security_markers_defaults_to_true() {
     let yaml = r#"
 schema_version: 1


### PR DESCRIPTION
## Summary
- add optional artifact dependency graph metadata via Markdown frontmatter and project.yaml code ownership
- add artifact impact/audit CLI commands and ART diagnostics in hlv check
- document legacy upgrade path and add smoke/unit coverage

## Tests
- cargo test
- make lint