### PR TITLE
Fix UTF-8-safe truncation for constraints output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "unicode-width 0.2.0",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 flate2 = "1"
 tar = "0.4"
 zip = "2"
+unicode-width = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/check/constraints.rs
+++ b/src/check/constraints.rs
@@ -6,6 +6,7 @@ use crate::check::{Diagnostic, Severity};
 use crate::model::policy::ConstraintFile;
 use crate::model::project::ProjectMap;
 use crate::util::command_parser::{parse_portable_command, CommandParseError};
+use crate::util::text::truncate_ellipsis;
 
 /// Default timeout for check_command execution (60 seconds).
 const CHECK_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
@@ -320,12 +321,7 @@ fn execute_check_command(cmd: &str, work_dir: &Path) -> (bool, String) {
                     } else {
                         format!("exit code {}", status.code().unwrap_or(-1))
                     };
-                    // Truncate long output
-                    let truncated = if output.len() > 200 {
-                        format!("{}...", &output[..200])
-                    } else {
-                        output
-                    };
+                    let truncated = truncate_check_output(&output);
                     return (false, truncated);
                 }
             }
@@ -341,6 +337,10 @@ fn execute_check_command(cmd: &str, work_dir: &Path) -> (bool, String) {
     }
 }
 
+fn truncate_check_output(output: &str) -> String {
+    truncate_ellipsis(output, 200)
+}
+
 fn check_command_failure_reason(err: &CommandParseError) -> String {
     match err {
         CommandParseError::EmptyCommand => "check_command is empty".to_string(),
@@ -352,5 +352,19 @@ fn check_command_failure_reason(err: &CommandParseError) -> String {
             "unsupported check_command syntax '{}' (use one executable per check_command; shell operators and shell variable expansion are not supported)",
             op
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_command_output_truncation_does_not_panic_on_multibyte_boundary() {
+        let output = format!("{}Жtail", "a".repeat(199));
+
+        let truncated = truncate_check_output(&output);
+
+        assert_eq!(truncated, format!("{}…", "a".repeat(199)));
     }
 }

--- a/src/tui/tabs/constraints.rs
+++ b/src/tui/tabs/constraints.rs
@@ -1,6 +1,7 @@
 use crate::model::policy::{ConstraintFile, PerformanceConstraints};
 use crate::model::project::ConstraintEntry;
 use crate::tui::app::App;
+use crate::util::text::truncate_display_ellipsis;
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph};
 
@@ -58,7 +59,7 @@ pub fn render(f: &mut Frame, area: Rect, app: &mut App) {
                     Span::styled(rule.severity.clone(), sev_style),
                     Span::raw("  "),
                     Span::styled(
-                        truncate(&rule.statement, 60),
+                        truncate_display_ellipsis(&rule.statement, 60),
                         Style::default().fg(Color::DarkGray),
                     ),
                 ]));
@@ -145,13 +146,5 @@ fn severity_style(severity: &str) -> Style {
         "medium" => Style::default().fg(Color::Blue),
         "low" => Style::default().fg(Color::DarkGray),
         _ => Style::default(),
-    }
-}
-
-fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        format!("{}...", &s[..max - 3])
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,1 +1,2 @@
 pub mod command_parser;
+pub mod text;

--- a/src/util/text.rs
+++ b/src/util/text.rs
@@ -1,0 +1,101 @@
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+pub fn truncate_ellipsis(s: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+
+    if s.chars().count() <= max_chars {
+        return s.to_string();
+    }
+
+    let mut out: String = s.chars().take(max_chars.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+pub fn truncate_display_ellipsis(s: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+
+    if UnicodeWidthStr::width(s) <= max_width {
+        return s.to_string();
+    }
+
+    if max_width == 1 {
+        return "…".to_string();
+    }
+
+    let content_width = max_width.saturating_sub(1);
+    let mut out = String::new();
+    let mut width = 0;
+
+    for ch in s.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if width + ch_width > content_width {
+            break;
+        }
+        width += ch_width;
+        out.push(ch);
+    }
+
+    out.push('…');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_ellipsis_returns_empty_for_zero_limit() {
+        assert_eq!(truncate_ellipsis("abc", 0), "");
+    }
+
+    #[test]
+    fn truncate_ellipsis_keeps_exact_char_limit() {
+        assert_eq!(truncate_ellipsis("abc", 3), "abc");
+    }
+
+    #[test]
+    fn truncate_ellipsis_truncates_ascii_with_single_ellipsis_char() {
+        assert_eq!(truncate_ellipsis("abcdef", 4), "abc…");
+    }
+
+    #[test]
+    fn truncate_ellipsis_does_not_panic_on_multibyte_boundary() {
+        let input = format!("{}Жtail", "a".repeat(199));
+
+        let truncated = truncate_ellipsis(&input, 200);
+
+        assert_eq!(truncated.chars().count(), 200);
+        assert!(truncated.ends_with('…'));
+        assert_eq!(truncated, format!("{}…", "a".repeat(199)));
+    }
+
+    #[test]
+    fn truncate_display_ellipsis_returns_empty_for_zero_width() {
+        assert_eq!(truncate_display_ellipsis("abc", 0), "");
+    }
+
+    #[test]
+    fn truncate_display_ellipsis_returns_ellipsis_for_one_width() {
+        assert_eq!(truncate_display_ellipsis("abc", 1), "…");
+    }
+
+    #[test]
+    fn truncate_display_ellipsis_truncates_ascii_by_display_width() {
+        assert_eq!(truncate_display_ellipsis("abcdef", 4), "abc…");
+    }
+
+    #[test]
+    fn truncate_display_ellipsis_respects_cjk_display_width() {
+        assert_eq!(truncate_display_ellipsis("界界a", 4), "界…");
+    }
+
+    #[test]
+    fn truncate_display_ellipsis_respects_emoji_display_width() {
+        assert_eq!(truncate_display_ellipsis("😀😀a", 4), "😀…");
+    }
+}


### PR DESCRIPTION
## Summary

- Add shared UTF-8-safe truncation helpers in `util::text`
- Replace byte-slice truncation in constraint command output
- Use display-width-aware truncation for the TUI constraints tab via `unicode-width`
- Add regression tests for multibyte UTF-8 boundaries, CJK, and emoji truncation

## Why

Constraint output and TUI text truncation used byte slicing, which could panic when truncating inside a multibyte UTF-8 character.

## Test Plan

- `cargo test`
- `cargo clippy`
- `cargo clippy -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`

Note: `make lint` could not be run because `make` is not installed in this Windows environment; its equivalent commands were run directly and passed.